### PR TITLE
removing redundant call to Board::GetStart

### DIFF
--- a/LabyrinthBoard/LabyrinthBoard/Solver.cpp
+++ b/LabyrinthBoard/LabyrinthBoard/Solver.cpp
@@ -58,6 +58,6 @@ bool Solver::PathExists(Board& board)
 		pStart->PrintInfo();
 		std::cout << std::endl << std::endl;
 
-		return PathExists_Internal(board, board.GetStart());
+		return PathExists_Internal(board, pStart);
 	}
 }


### PR DESCRIPTION
if(pStar != NULL) we all ready know the result of Board::GetStart